### PR TITLE
Windows compatible

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -1,5 +1,5 @@
 {
-	"name": "Derbot Engine",
+	"name": "derbot engine",
 	"description": "The Derbot Game Engine",
 	"authors": ["Derbdale"],
 	"license": "GPL-2.0",
@@ -19,6 +19,22 @@
 			"targetPath": "build/release",
 			"preBuildCommands":["rm -r build/release", "mkdir build\\release", "CLS"],
 			"postBuildCommands":["cp dlls/* build/release", "cp assets build/release/assets -R", "rm -r .dub"]
+		},
+		
+		{
+			"name": "Debug-Windows",
+			"targetType": "executable",
+			"targetPath":"build\\debug",
+			"preBuildCommands":["rd /s /q build\\debug", "md build\\debug", "CLS"],
+			"postBuildCommands":["copy dlls\\* build\\debug", "xcopy assets build\\debug\\assets\\ /s /e", "rd /s /q .dub"]
+		},
+		{
+			"name": "Release-Windows",
+			"targetType": "executable",
+			"lflags": ["-L/exet:nt/su:windows"],
+			"targetPath": "build\\release",
+			"preBuildCommands":["rd /s /q build\\release", "md build\\release", "CLS"],
+			"postBuildCommands":["copy dlls\\* build\\release", "xcopy assets build\\release\\assets\\ /s /e", "rd /s /q .dub"]
 		}
 	],
 	"buildOptions": [

--- a/dub.json
+++ b/dub.json
@@ -1,5 +1,5 @@
 {
-	"name": "derbot engine",
+	"name": "derbot- engine",
 	"description": "The Derbot Game Engine",
 	"authors": ["Derbdale"],
 	"license": "GPL-2.0",

--- a/dub.json
+++ b/dub.json
@@ -1,5 +1,5 @@
 {
-	"name": "derbot- engine",
+	"name": "derbot-engine",
 	"description": "The Derbot Game Engine",
 	"authors": ["Derbdale"],
 	"license": "GPL-2.0",

--- a/src/util/fontrenderer.d
+++ b/src/util/fontrenderer.d
@@ -51,8 +51,8 @@ class FontRenderer{
 
 		foreach(char c; text.toUpper){
 			glBegin(GL_QUADS);
-				float topLeftX = ((FontData.characters.indexOf(c) - (floor(FontData.characters.indexOf(c)/10)*10))*FontData.size[font] + FontData.x[font][c])/(FontData.size[font]*10);
-				float topLeftY = (floor(FontData.characters.indexOf(c)/10)*FontData.size[font] + FontData.y[font][c])/(FontData.size[font]*10);
+				float topLeftX = ((FontData.characters.indexOf(c) - (floor(cast(float)(FontData.characters.indexOf(c)/10))*10))*FontData.size[font] + FontData.x[font][c])/(FontData.size[font]*10);
+				float topLeftY = (floor(cast(float)(FontData.characters.indexOf(c)/10))*FontData.size[font] + FontData.y[font][c])/(FontData.size[font]*10);
 				glTexCoord2f(topLeftX, topLeftY);
 				glVertex3f(0.0f, 0.0f, 0.0f);
 				glTexCoord2f(topLeftX+(FontData.w[font][c]/(FontData.size[font]*10)), topLeftY);


### PR DESCRIPTION
I've changed the following:
- The name of the package
- Added Windows Debug and Release configurations
- Casted result into a float in `std.math.floor`, in `fontrenderer.d`

Running `dmd build` on Windows gave an error that the package couldn't be found. Changing the package name (in `dub.json`) to lowercase fixed the problem.

The configurations were using the commands **rm**, **mkdir** and **cp** which does not exist on Windows. I added separate configurations for Windows, which use Windows specific commands.

Running `dmd build` on Windows gave errors that floor in `fontrenderer.d` couldn't be determined between floor, double etc. so I casted the stuff inside the brackets to float.
